### PR TITLE
AT_01.05.04 | Login by email tab UI > Insure Password label has text …

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/loginPopupSection/US_01.05_LoginByEmailTab_UI.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/loginPopupSection/US_01.05_LoginByEmailTab_UI.cy.js
@@ -25,4 +25,12 @@ describe('US_01.05 | Login By Email Tab UI', () => {
             .should('be.visible')
             .and('have.attr', 'placeholder', this.inputField.loginPopup.emailInputField);
     });
-})
+
+    it('AT_01.05.04 | Login by email tab UI > Insure Password label has text "Password"', () => {
+        loginPopup
+            .getPasswordLabel()
+            .should('be.visible')
+            .and('have.text', 'Password')
+    })
+});
+

--- a/cypress/e2e/testUiAndFunction/startPage/loginPopupSection/US_01.05_LoginByEmailTab_UI.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/loginPopupSection/US_01.05_LoginByEmailTab_UI.cy.js
@@ -11,6 +11,10 @@ describe('US_01.05 | Login By Email Tab UI', () => {
         cy.fixture('startPage/inputField').then(inputField => {
             this.inputField = inputField;
         });
+        cy.fixture('startPage/label').then(label => {
+            this.label = label
+        });
+
         cy.visit('/');
         startPage.clickLoginButton();
     });
@@ -26,11 +30,10 @@ describe('US_01.05 | Login By Email Tab UI', () => {
             .and('have.attr', 'placeholder', this.inputField.loginPopup.emailInputField);
     });
 
-    it('AT_01.05.04 | Login by email tab UI > Insure Password label has text "Password"', () => {
+    it('AT_01.05.04 | Insure Password label has text "Password"', function() {
         loginPopup
             .getPasswordLabel()
             .should('be.visible')
-            .and('have.text', 'Password')
+            .and('have.text', this.label.labelPassword.text)
     })
 });
-

--- a/cypress/fixtures/startPage/label.json
+++ b/cypress/fixtures/startPage/label.json
@@ -1,0 +1,6 @@
+{
+    "labelPassword": {
+        "text": "Password"    
+    }
+
+}

--- a/cypress/pageObjects/StartPage.js
+++ b/cypress/pageObjects/StartPage.js
@@ -22,6 +22,7 @@ export class LoginPopup {
     getForgotYourPasswordLink = () => cy.get('#loginModal .pull-right a');
     getEmailInput = () => cy.get('#byemail input[placeholder="Email"]');
     getHeaderTextElement = () => cy.get('.text-center');
+    getPasswordLabel = () => cy.get('#byemail div:nth-last-of-type(2) label')
 
 
     // Methods


### PR DESCRIPTION
…'Password'

https://trello.com/c/uMyTIAeR/204-at010504-login-by-email-tab-ui-insure-by-email-tab-is-visible