### PR TITLE
AT_01.02.01 | Start page > Verify Link 'Register account now': visible and have text 'Register account now'

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/loginRegisterSection/US_01.02_LoginRegisterSectionElementsUIandFunc.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/loginRegisterSection/US_01.02_LoginRegisterSectionElementsUIandFunc.cy.js
@@ -1,0 +1,23 @@
+/// <reference types="Cypress" />
+
+import { StartPage } from "../../../../pageObjects/StartPage";
+
+const startPage = new StartPage();
+
+describe('US_01.02 | Login-register section elements UI and functionality', () => {
+
+    beforeEach(function () {
+        cy.fixture('startPage/links').then(links => {
+            this.links = links;
+        });
+
+		cy.visit('/')
+	});
+
+    it('AT_01.02.01 | Verify Link "Register account now": visible and have text "Register account now"', function () {
+        startPage
+        .getRegisterAccountLink()
+        .should('be.visible')
+        .and('have.text', this.links.registerAccountNowEnglishText);
+    });
+})

--- a/cypress/fixtures/startPage/links.json
+++ b/cypress/fixtures/startPage/links.json
@@ -1,0 +1,3 @@
+{
+    "registerAccountNowEnglishText": "Register account now"
+}


### PR DESCRIPTION
https://trello.com/c/0OJSGBcy/148-at010201-start-page-verify-link-register-account-now-visible-and-have-text-register-account-now