### PR TITLE
AT_01.07.01 | Login by email tab negative > Verify error message after click SignIn with empty login fields

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/loginPopupSection/US_01.07_LoginByEmailTab_negative.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/loginPopupSection/US_01.07_LoginByEmailTab_negative.cy.js
@@ -1,0 +1,34 @@
+/// <reference types="Cypress" />
+
+import {StartPage} from "../../../../pageObjects/StartPage.js";
+import {LoginPopup} from "../../../../pageObjects/StartPage.js";
+
+const startPage = new StartPage();
+const loginPopup = new LoginPopup();
+
+describe('US_01.07 | Login by email tab negative', () => {
+    beforeEach(function () {
+        cy.fixture('startPage/alert').then(alert => {
+            this.alert = alert;
+        });
+        cy.visit('/');
+        startPage.clickLoginButton();
+    });
+
+    it('AT_01.07.01 | Verify error message after click SignIn with empty login fields', function () {
+        loginPopup
+            .getEmailInput()
+            .clear()
+            .should ('not.have.value');
+        loginPopup
+            .getPasswordInput()
+            .clear()
+            .should ('not.have.value');
+        loginPopup
+            .clickSignInButton();
+        loginPopup.getMessageAlert()
+            .should("be.visible")
+            .and('have.text',this.alert.loginPopupMessageAlert);
+        });
+
+});

--- a/cypress/fixtures/startPage/alert.json
+++ b/cypress/fixtures/startPage/alert.json
@@ -5,5 +5,7 @@
     "registerPopupErrorMessage": {
         "emptyNameField": "Please enter your name",
         "emptyCompanyField": "Please enter your company name"
-    }
+    },
+    "loginPopupMessageAlert": "Wrong email or passwordYou can REGISTER a new one or RESTORE a forgotten password"
+    
 }

--- a/cypress/pageObjects/StartPage.js
+++ b/cypress/pageObjects/StartPage.js
@@ -28,13 +28,18 @@ export class LoginPopup {
     getHeaderTextElement = () => cy.get('.text-center');
     getPasswordLabel = () => cy.get('#byemail div:nth-last-of-type(2) label');
     getHeaderText = () => cy.get('div[style*="padding: 15"] :nth-child(2)');
-
-
+    getPasswordInput = () => cy.get('#byemail input[name="password"]');
+    getSignInButton = () => cy.get('#byemail input[value="SIGN IN"]');
+    getMessageAlert = () => cy.get('div.alert');
+    
     // Methods
 
     clickForgotYourPasswordLink() {
         this.getForgotYourPasswordLink().click();
     };
+    clickSignInButton() {
+        this.getSignInButton().click();
+    };    
 }
 
 export class RestorePopup {


### PR DESCRIPTION
https://trello.com/c/C5jy7Cce/263-at010701-login-by-email-tab-negative-verify-error-message-after-click-signin-with-empty-login-fields