### PR TITLE
AT_01.12.01 | After clicking `Forgot your password?` link the Registered Agent Account Popup window is closed and `Restore password` popup window appears.

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/loginRegisterSection/US_01.12_FooterUIandFunc.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/loginRegisterSection/US_01.12_FooterUIandFunc.cy.js
@@ -1,0 +1,25 @@
+/// <reference types="Cypress" />
+
+import {StartPage} from "../../../../pageObjects/StartPage";
+import {LoginPopup} from "../../../../pageObjects/StartPage";
+import {RegisterPopup} from "../../../../pageObjects/StartPage";
+import {RestorePopup} from "../../../../pageObjects/StartPage";
+
+const startPage = new StartPage();
+const loginPopup = new LoginPopup();
+const registerPopup = new RegisterPopup();
+const restorePopup = new RestorePopup();
+
+describe('US_01.12 | Footer UI and functionality', () => {
+
+    beforeEach(function () {
+		cy.visit('/')
+	});
+
+    it('AT_01.12.01 | After clicking "Forgot your password?" link the Registered Agent Account Popup window is closed and "Restore password" popup window appears', () => {
+        startPage.getRegisterAccountLink()
+        loginPopup.clickForgotYourPasswordLink()
+        registerPopup.getRegisterAgentAccountHeader().should('not.be.visible')
+        restorePopup.getRestorePasswordHeader().should('be.visible')
+    })
+})

--- a/cypress/pageObjects/StartPage.js
+++ b/cypress/pageObjects/StartPage.js
@@ -31,13 +31,13 @@ export class LoginPopup {
     getEmailLabel = () => cy.get('#loginModal .tab-content #byemail form div label').first();
     getPasswordInput = () => cy.get('#byemail input[name="password"]');
     getSignInButton = () => cy.get('#byemail input[value="SIGN IN"]');
-    getMessageAlert = () => cy.get('div.alert');    
+    getMessageAlert = () => cy.get('div.alert');
 
 
     // Methods
 
     clickForgotYourPasswordLink() {
-        this.getForgotYourPasswordLink().click();
+        this.getForgotYourPasswordLink().click({force: true});
     };
     clickSignInButton() {
         this.getSignInButton().click();
@@ -50,6 +50,7 @@ export class RestorePopup {
     getEmailInput = () => cy.get('#restoreModal input[placeholder="Email"]');
     getRestoreButton = () => cy.get('#restoreModal input[type="submit"]');
     getMessageAlert = () => cy.get('#restoreModal div.alert');
+    getRestorePasswordHeader = () => cy.get('#restoreModal h2');
 
 
     // Methods
@@ -72,6 +73,7 @@ export class RegisterPopup {
     getEmailInputField = () => cy.get('input[placeholder="You will get your password by email"]')
     getPhoneInputField = () => cy.get('input[name="phone"]')
     getErrorMessage = () => cy.get('#registerModal .help-block.error')
+    getRegisterAgentAccountHeader = () => cy.get('#registerModal h2')
 
     // Methods
 


### PR DESCRIPTION
https://trello.com/c/aVXpijLq/157-at011201-start-page-register-agent-account-popup-footer-ui-and-functionality-after-clicking-forgot-your-password-link-the-regist