### PR TITLE
AT_01.12.02 | Start page > Register Agent Account Popup > Footer UI and functionality > Insure Footer elements are visible

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/registerAgentAccountPopupSection/US_01.12_FooterUIandFunc.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/registerAgentAccountPopupSection/US_01.12_FooterUIandFunc.cy.js
@@ -22,4 +22,10 @@ describe('US_01.12 | Footer UI and functionality', () => {
         registerPopup.getRegisterAgentAccountHeader().should('not.be.visible')
         restorePopup.getRestorePasswordHeader().should('be.visible')
     })
+
+    it('AT_01.12.02 | Verify Footer elements are visible' , () => {
+        //startPage.getRegisterAccountLink();
+        startPage.clickRegisterAccountLink();
+        registerPopup.getForgotYourPasswordLink().should('be.visible').should('have.css','color', 'rgb(66, 139, 202)');
+    })
 })

--- a/cypress/pageObjects/StartPage.js
+++ b/cypress/pageObjects/StartPage.js
@@ -81,6 +81,7 @@ export class RegisterPopup {
     getPhoneInputField = () => cy.get('input[name="phone"]')
     getErrorMessage = () => cy.get('#registerModal .help-block.error')
     getRegisterAgentAccountHeader = () => cy.get('#registerModal h2')
+    getForgotYourPasswordLink = () => cy.get('#registerModal .pull-right a')
 
     // Methods
 


### PR DESCRIPTION
[[AT_01.12.02 | Start page > Register Agent Account Popup > Footer UI and functionality > Insure Footer elements are visible](https://trello.com/c/aleMsnIg/305-at011202-name)](https://trello.com/c/aleMsnIg/305-at011202-name)