### PR TITLE
AT_04.11.01 | Create booking page > Deparure date > Calendar week functionality >Verify that you can click on last date field if it has not expired

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/departureDateSection/US_04.11_CalendarWeekFunc.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/departureDateSection/US_04.11_CalendarWeekFunc.cy.js
@@ -13,6 +13,19 @@ describe('US_04.11 | Calendar week functionality', () => {
 		cy.login(AGENT.email, AGENT.password)
 	});
 
+	it('AT_04.11.01|Verify that you can click on last date field if it has not expired', function() {
+
+        createBookingPage.getCalendarDaySelectionWrapper()
+            .not('unavailable')    
+            .last()
+            .click()
+			.then(($date) => {
+				let dayOfWeek = $date;
+
+				expect(dayOfWeek).to.have.class('selected')
+			});
+    });
+
 	it('AT_04.11.02 | Verify chosen date, current month and year are displayed in the Departure on section', function () {
 		const current = new Date()
 		const thailandCurrentMonthAndYear = new Date(current).toLocaleString('en-GB', { month: 'short', year: 'numeric', timeZone: 'Asia/Ho_Chi_Minh' })


### PR DESCRIPTION
[AT_04.11.01 | Create booking page > Deparure date > Calendar week functionality >Verify that you can click on last date field if it has not expired](https://trello.com/c/PT2O6TEU/186-at041101-create-booking-page-deparure-date-calendar-week-functionality-verify-that-you-can-click-on-any-date-field-if-it-has-not)