### PR TITLE
AT_04.13.02 | Verify the first option of the Month dropdown menu has the current month and the current year

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.13_MonthDropdownMenu.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.13_MonthDropdownMenu.cy.js
@@ -18,4 +18,13 @@ describe('US_04.13 | Create booking page > Departure date > Month dropdown UI an
         createBookingPage.getMonthDropdownList().should('be.visible')
             .and('have.length', 13);
     })
+
+    it('AT_04.13.02 | Verify the first option of the Month dropdown menu has the current month and the current year', function () {
+        const current = new Date()
+        const thailandCurrentMonthAndYear = new Date(current).toLocaleString('en-GB', { month: 'short', year: 'numeric', timeZone: 'Asia/Ho_Chi_Minh' })
+        createBookingPage.getMonthDropdownList()
+            .eq(0)
+            .invoke('text')
+            .should('eq', thailandCurrentMonthAndYear)
+    })
 })


### PR DESCRIPTION
https://trello.com/c/TZ8AFmml/261-at041302-verify-that-the-first-option-of-the-month-dropdown-menu-has-the-current-month-and-the-current-year