### PR TITLE
AT_01.15.04 | Error message is displayed when trying to register without phone number

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/us_01.15_RegisterAgentNegative.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/us_01.15_RegisterAgentNegative.cy.js
@@ -69,4 +69,14 @@ describe('US_01.15 | Register Agent Negative', function () {
             .should('be.visible')
             .and('have.text', this.startPage.alert.registerPopupErrorMessage.emptyEmailField)
     });
+
+    it('AT_01.15.04 | Error message is displayed when trying to register without phone number', function() {
+        registerPopup.enterName(randomFullName)
+        registerPopup.enterCompanyName(randomCompanyName)
+        registerPopup.enterEmail(randomEmail)
+        registerPopup.clickRegisterButton()
+        registerPopup.getErrorMessage()
+                     .should('be.visible')
+                     .and('have.text', this.startPage.alert.registerPopupErrorMessage.emptyPhoneField)
+    });
 })

--- a/cypress/fixtures/startPage.json
+++ b/cypress/fixtures/startPage.json
@@ -6,7 +6,8 @@
         "registerPopupErrorMessage": {
             "emptyNameField": "Please enter your name",
             "emptyCompanyField": "Please enter your company name",
-            "emptyEmailField": "Please enter valid email"
+            "emptyEmailField": "Please enter valid email",
+            "emptyPhoneField": "Please enter your phone number"
         },
         "loginPopupMessageAlert": "Wrong email or passwordYou can REGISTER a new one or RESTORE a forgotten password"
     },


### PR DESCRIPTION
https://trello.com/c/7cL2ChFS/256-at011504-start-page-register-agent-negative-error-message-is-displayed-when-trying-to-register-without-phone-number