### PR TITLE
AT_01.05.02 | Login by email tab UI > Insure Email label text is 'Email'

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/US_01.05_LoginByEmailTab_UI.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/US_01.05_LoginByEmailTab_UI.cy.js
@@ -39,4 +39,10 @@ describe('US_01.05 | Login By Email Tab UI', () => {
             .getEmailLabel()
             .should('have.css','color', this.startPage.label.labelEmail.color)
     });
+
+    it('AT_01.05.02 | Insure Email label text is "Email"', function () {
+        loginPopup
+        .getEmailLabel()
+        .should('have.text', this.startPage.label.labelEmail.text)
+    });
 });

--- a/cypress/fixtures/startPage.json
+++ b/cypress/fixtures/startPage.json
@@ -42,7 +42,8 @@
             "text": "Password"
         },
         "labelEmail": {
-            "color": "rgb(153, 153, 153)"
+            "color": "rgb(153, 153, 153)",
+            "text": "Email"
         }
     },
     "links": {

--- a/cypress/pageObjects/StartPage.js
+++ b/cypress/pageObjects/StartPage.js
@@ -46,6 +46,7 @@ export class LoginPopup {
     getPasswordInput = () => cy.get('#byemail input[name="password"]');
     getSignInButton = () => cy.get('#byemail input[value="SIGN IN"]');
     getMessageAlert = () => cy.get('div.alert');
+    getEmailLabel = () => cy.get('#byemail > .form-horizontal > :nth-child(3) > .col-sm-4');
 
 
     // Methods


### PR DESCRIPTION
https://trello.com/c/7ZU6tQnJ/342-at010502-login-by-email-tab-ui-insure-email-label-text-is-email

AT_01.05.02 | Login by email tab UI > Insure Email label text is 'Email'