### PR TITLE
AT_01.15.07 | Error message is displayed when trying to register with previously used email

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/us_01.15_RegisterAgentNegative.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/us_01.15_RegisterAgentNegative.cy.js
@@ -79,4 +79,17 @@ describe('US_01.15 | Register Agent Negative', function () {
                      .should('be.visible')
                      .and('have.text', this.startPage.alert.registerPopupErrorMessage.emptyPhoneField)
     });
+
+    it('AT_01.15.07 | Error message is displayed when trying to register  with previously used email', function() {
+        registerPopup.enterName(randomFullName)
+        registerPopup.enterCompanyName(randomCompanyName)
+        registerPopup.enterEmail(this.startPage.data.previouslyUsedEmail)
+        registerPopup.enterPhoneNumber(randomPhoneNumber)
+        registerPopup.clickRegisterButton()
+        registerPopup
+            .getErrorMessage()
+            .should('be.visible')
+            .and('have.text', this.startPage.alert.registerPopupErrorMessage.emailIsPreviouslyUsed)
+    });
+
 })

--- a/cypress/fixtures/startPage.json
+++ b/cypress/fixtures/startPage.json
@@ -7,7 +7,8 @@
             "emptyNameField": "Please enter your name",
             "emptyCompanyField": "Please enter your company name",
             "emptyEmailField": "Please enter valid email",
-            "emptyPhoneField": "Please enter your phone number"
+            "emptyPhoneField": "Please enter your phone number",
+            "emailIsPreviouslyUsed": "This Email is not allowed to use current website"
         },
         "loginPopupMessageAlert": "Wrong email or passwordYou can REGISTER a new one or RESTORE a forgotten password"
     },
@@ -45,5 +46,8 @@
     },
     "links": {
         "registerAccountNowEnglishText": "Register account now"
+    },
+    "data": {
+        "previouslyUsedEmail": "testAgent6@qatest.site"
     }
 }


### PR DESCRIPTION
https://trello.com/c/7naOM4mF/366-at011507-start-page-register-agent-negative-error-message-is-displayed-when-trying-to-register-with-previously-used-email