### PR TITLE
AT_04.13.04 | Verify month dropdown menu has 13 consecutive months and year options starting from current month and year

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.13_MonthDropdownMenu.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.13_MonthDropdownMenu.cy.js
@@ -1,6 +1,7 @@
 /// <reference types = "Cypress" />
 
 import CreateBookingPage from "../../../pageObjects/CreateBookingPage.js";
+import arrayOfConsetutiveMonths from "../../../support/utilities/createArrayOfMonths.js";
 
 const createBookingPage = new CreateBookingPage();
 
@@ -35,5 +36,13 @@ describe('US_04.13 | Create booking page > Departure date > Month dropdown UI an
                 selectedMonth => createBookingPage.getMonthDropdownSelect()
                     .should('have.value', selectedMonth)
             )
+    })
+
+    it('AT_04.13.04 | Verify month dropdown menu has 13 consecutive months and year options starting from current month and year', function () {
+        arrayOfConsetutiveMonths()
+
+        createBookingPage.getMonthDropdownList().each(($el, i) => {
+            expect($el.text()).to.deep.eq(arrayOfConsetutiveMonths()[i])
+        })
     })
 })

--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.13_MonthDropdownMenu.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.13_MonthDropdownMenu.cy.js
@@ -39,8 +39,6 @@ describe('US_04.13 | Create booking page > Departure date > Month dropdown UI an
     })
 
     it('AT_04.13.04 | Verify month dropdown menu has 13 consecutive months and year options starting from current month and year', function () {
-        arrayOfConsetutiveMonths()
-
         createBookingPage.getMonthDropdownList().each(($el, i) => {
             expect($el.text()).to.deep.eq(arrayOfConsetutiveMonths()[i])
         })

--- a/cypress/support/utilities/createArrayOfMonths.js
+++ b/cypress/support/utilities/createArrayOfMonths.js
@@ -1,0 +1,14 @@
+const arrayOfConsetutiveMonths = () => {
+	let consecutiveMonths = []
+	let count = 0
+	while (count <= 12) {
+		const current = new Date()
+		current.setMonth(current.getMonth() + count)
+		current.setDate(1)
+		const month = current.toLocaleString('en-US', { month: 'short', year: 'numeric', timeZone: 'Asia/Ho_Chi_Minh' })
+		consecutiveMonths.push(month)
+		count++
+	}
+	return consecutiveMonths
+}
+export default arrayOfConsetutiveMonths

--- a/cypress/support/utilities/createArrayOfMonths.js
+++ b/cypress/support/utilities/createArrayOfMonths.js
@@ -3,8 +3,8 @@ const arrayOfConsetutiveMonths = () => {
 	let count = 0
 	while (count <= 12) {
 		const current = new Date()
-		current.setMonth(current.getMonth() + count)
 		current.setDate(1)
+		current.setMonth(current.getMonth() + count)
 		const month = current.toLocaleString('en-US', { month: 'short', year: 'numeric', timeZone: 'Asia/Ho_Chi_Minh' })
 		consecutiveMonths.push(month)
 		count++


### PR DESCRIPTION
https://trello.com/c/u1bW8GXH/365-at041304-verify-month-dropdown-menu-has-13-consecutive-months-and-year-options-starting-from-current-month-and-year