### PR TITLE
AT_04.07.02_Verify that after clicking on any space outside of the opened drop-down menu, the drop-down menu will close.

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.07_ArrivalDropdown.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.07_ArrivalDropdown.cy.js
@@ -21,4 +21,11 @@ describe('US_04.07_Arrival Dropdown UI and functionality ', () => {
         createBookingPage.clickArrivalStationDropdown()
         createBookingPage.getArrivalStationList().should('be.visible')
     });
+
+    it('AT_04.07.02 | Verify that after clicking on any space outside of the opened drop-down menu, the drop-down menu will close', function () {
+        createBookingPage.clickArrivalStationDropdown();
+        createBookingPage.clickArrivalStationDropdown();
+        createBookingPage.getArrivalSearchField().should('not.exist');
+        createBookingPage.getArrivalStationList().should('not.exist');
+     });
 })

--- a/cypress/pageObjects/CreateBookingPage.js
+++ b/cypress/pageObjects/CreateBookingPage.js
@@ -27,6 +27,7 @@ class CreateBookingPage {
     getSelectedSeats = () => cy.get('table.seats tr td[class="seat selected"]');
     getRowsSeatsSeatSection = () => cy.get('.seat-chart .seats tr:not(tr:first-child)')
     getAmountOfChosenPass = () => cy.get('.box-default .passenger-wrapper .passenger-row')
+    getArrivalSearchField = () => cy.get('.select2-search__field');
 
     
     // Methods


### PR DESCRIPTION
TC - https://trello.com/c/WqsG9bRy/346-tc040702-create-booking-page-arrival-dropdown-ui-and-functionality-verify-that-after-clicking-on-any-space-outside-of-the-opened
AT - https://trello.com/c/84ZsFNkP/347-at040702-create-booking-page-arrival-dropdown-ui-and-functionality-verify-that-after-clicking-on-any-space-outside-of-the-opened