### PR TITLE
ERR | US_04.12 | Calendar month functionality > AT_04.12.01 | Create booking page > Verify any date earlier than the current date is not available

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.12_CalendarMonthFunc.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.12_CalendarMonthFunc.cy.js
@@ -54,14 +54,13 @@ describe('US_04.12 | Calendar month functionality', () => {
 		})
 	})
 
-	it.skip('AT_04.12.01 | Create booking page > Verify any date earlier than the current date is not available.', function () {
+	it('AT_04.12.01 | Create booking page > Verify any date earlier than the current date is not available.', function () {
 		let date = new Date() 
-        let fullDateThailand = date.toLocaleString('en-GB', { day: 'numeric' , month: 'short', year: 'numeric', timeZone: 'Asia/Bangkok' })
-        let currentDateThailand = +fullDateThailand.slice(0, 2)
-		let currentMonthAndYear = fullDateThailand.slice(3)
+		let dateThailand = date.toLocaleString('en-GB', { day: 'numeric', timeZone: 'Asia/Bangkok' })
+		let currentMonthAndYear = date.toLocaleString('en-GB', { month: 'short', year: 'numeric', timeZone: 'Asia/Bangkok'})
 		createBookingPage.getMonthDropdownSelect().select(currentMonthAndYear)
 		createBookingPage.getCalendarDays().not('.shaded').each(($el) => {
-            if($el.text() < currentDateThailand){
+            if($el.text() < dateThailand){
                 expect($el).to.have.class(this.createBookingPage.class.unavailableClass)
             }          
 		})		


### PR DESCRIPTION
https://trello.com/c/UV5LO8rO/506-err-us0412-calendar-month-functionality-at041201-create-booking-page-verify-any-date-earlier-than-the-current-date-is-not-availa