### PR TITLE
AT_04.15.02 | While selected Month button, the Week button does not have the attribute "selected" and its background color is rgb(255, 255, 255)

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.15_MonthBtnElementsView.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.15_MonthBtnElementsView.cy.js
@@ -12,16 +12,22 @@ describe('US_04.15 | Create booking page > Month button elements view', () => {
         createBookingPage.clickMonthBtn();
     })
 
-    beforeEach(function() {
+    beforeEach(function () {
         cy.fixture('createBookingPage.json').then(createBookingPage => {
             this.createBookingPage = createBookingPage;
         })
     })
 
-    it('AT_04.15.01 Month button is visible, has the attribute "selected" and its background color is #00a65a( rgb(0, 166, 90) )', function() {
+    it('AT_04.15.01 Month button is visible, has the attribute "selected" and its background color is #00a65a( rgb(0, 166, 90) )', function () {
         createBookingPage.getMonthBtn()
             .should('be.visible')
             .and('have.class', 'selected')
             .and('have.css', 'background-color', this.createBookingPage.selectedMonthBtnBackgroundColor);
+    })
+
+    it('AT_04.15.02 | While selected Month button, the Week button does not have the attribute "selected" and its background color is rgb(255, 255, 255)', function () {
+        createBookingPage.getWeekButton()
+            .should('not.have.class', 'selected')
+            .and('have.css', 'background-color', this.createBookingPage.notSelectedWeekBtnBackgroundColor);
     })
 });

--- a/cypress/fixtures/createBookingPage.json
+++ b/cypress/fixtures/createBookingPage.json
@@ -88,5 +88,8 @@
     "weekDayFields": {
          "quantity": "7"
     }, 
-    "selectedMonthBtnBackgroundColor": "rgb(0, 166, 90)"
+
+    "selectedMonthBtnBackgroundColor": "rgb(0, 166, 90)",
+
+    "notSelectedWeekBtnBackgroundColor": "rgb(255, 255, 255)"
 }


### PR DESCRIPTION
https://trello.com/c/BaNweIsK/561-at041502-create-booking-page-month-button-elements-view-while-the-month-button-is-selected-the-week-button-does-not-have-the-att