### PR TITLE
RF_AC_04.11.03 | Verify that if the date has expired, then the field with it is not clickable

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.11_CalendarWeekFunc.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.11_CalendarWeekFunc.cy.js
@@ -55,7 +55,7 @@ describe('US_04.11 | Calendar week functionality', () => {
 		createBookingPage.getCalendarDays().each(($el) => {
 			if($el.hasClass('unavailable')){
 
-				expect($el).to.have.css('cursor',this.createBookingPage.unavailableDayField.cursor);
+				expect($el).to.have.css('background-color',this.createBookingPage.unavailableDayField.backgroundColor);
 			}
 		})
 	});

--- a/cypress/fixtures/createBookingPage.json
+++ b/cypress/fixtures/createBookingPage.json
@@ -72,7 +72,8 @@
     },
 
     "unavailableDayField": {
-        "cursor": "not-allowed"
+        "cursor": "not-allowed",
+        "backgroundColor": "rgb(226, 226, 226)"
     },
     "class": {
         "unavailableClass": "unavailable"


### PR DESCRIPTION
https://trello.com/c/42qAs70L/568-rf-at041103verify-that-if-the-date-has-expired-then-the-field-with-it-is-not-clickable