### PR TITLE
AT_04.15.03 | Month dropdown menu is visible and available only after the Month button is chosen

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.15_MonthBtnElementsView.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.15_MonthBtnElementsView.cy.js
@@ -30,4 +30,14 @@ describe('US_04.15 | Create booking page > Month button elements view', () => {
             .should('not.have.class', 'selected')
             .and('have.css', 'background-color', this.createBookingPage.notSelectedWeekBtnBackgroundColor);
     })
+
+    it('AT_04.15.03 | Month dropdown menu (to the left of the Week button) is visible and available only after the Month button is chosen', function () {
+        createBookingPage.getMonthDropdownSelect()
+            .should('be.visible');
+
+        createBookingPage.clickWeekBtn();
+
+        createBookingPage.getMonthDropdownSelect()
+            .should('not.be.visible');         
+    })
 });

--- a/cypress/pageObjects/CreateBookingPage.js
+++ b/cypress/pageObjects/CreateBookingPage.js
@@ -46,6 +46,7 @@ class CreateBookingPage {
     getPlaceholderPassengerName = () => cy.get('input[placeholder="Passenger name"]')
     getPlaceholderPhoneNumber = () => cy.get('[placeholder="Phone number"]')
     getMainPassengerSelectedSeatByDefault = () => cy.get('div[class="col-lg-12 passenger-row"] span[class="seat-number"]')
+
     //Seat selection
     getSeatSelectionDropdown = () => cy.get('.layout-wrapper .title select.passengers-amount');
     getSeatSelectionDropdownList = () => cy.get('.layout-wrapper .title select.passengers-amount option');
@@ -149,6 +150,10 @@ class CreateBookingPage {
             return passengersAmount
         })
     };
+
+    clickWeekBtn() {
+        this.getWeekButton().click();
+    }
 
 }
 export default CreateBookingPage; 


### PR DESCRIPTION
https://trello.com/c/2qEByZiK/576-at041503-create-booking-page-month-button-elements-view-month-dropdown-menu-to-the-left-of-the-week-button-is-visible-and-availa