### PR TITLE
AT_04.15.06 | Calendar-day-selection bloc

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.15_MonthBtnElementsView.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.15_MonthBtnElementsView.cy.js
@@ -51,4 +51,16 @@ describe('US_04.15 | Create booking page > Month button elements view', () => {
 
         createBookingPage.getLabelCalendar().should('have.text', currentMonthAndYear);
     })
+
+    it('AT_04.5.06 | Calendar-day-selection block (under the calendar label) is visible and has at least 28 days', function () {
+        createBookingPage.getCalendarDays().each($el => {
+            cy.wrap($el).should('be.visible');
+        });
+
+        createBookingPage.getCalendarDays().then($el => {
+            let quantityOfDays = $el.length;
+            
+            expect(quantityOfDays).to.be.at.least(28);
+        })
+    })
 })


### PR DESCRIPTION
https://trello.com/c/LwrhZzb2/656-at041506-create-booking-page-month-button-elements-view-calendar-day-selection-block-under-the-calendar-label-is-visible-and-has