### PR TITLE
AT_04.12.05 | Tickets are not available for tomorrow (the current date by GMT+7)

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.12_CalendarMonthFunc.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.12_CalendarMonthFunc.cy.js
@@ -77,4 +77,14 @@ describe('US_04.12 | Calendar month functionality', () => {
 			cy.wrap($el).should('have.class', 'disabled')
 		})
 	});
+
+	it('AT_04.12.05 | Tickets are not available for tomorrow (the current date by GMT+7)', () => {
+		const tomorrowDayThailand = getCustomCalendarDay(1)
+
+		createBookingPage.clickCalendarDay(tomorrowDayThailand)
+
+		createBookingPage.getDepartureTripCardsList().each(($el) => {
+			cy.wrap($el).should('have.class', 'disabled')
+		})
+	});
 })


### PR DESCRIPTION
https://trello.com/c/GVoLCQS3/717-at041205-tickets-are-not-available-for-tomorrow-the-current-date-by-gmt7