### PR TITLE
AT_04.16.04 | 'Earliest' button has text 'Earliest' in white color rgb(255, 255, 255)

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.16_DepartureOnDefault.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.16_DepartureOnDefault.cy.js
@@ -36,4 +36,10 @@ describe('US_04.16 | Departure On UI by default', () => {
             .and('have.css', 'background-color', this.createBookingPage.greenColor);
     })
 
+    it('AT_04.16.04 | "Earliest" button has text "Earliest" in white color rgb(255, 255, 255)', function() {
+        createBookingPage.getBtnDepartureErliest()
+        .should('have.text', this.createBookingPage.earliestBtnText)
+        .and('have.css', 'color', this.createBookingPage.whiteColor);
+    })
+
 });

--- a/cypress/fixtures/createBookingPage.json
+++ b/cypress/fixtures/createBookingPage.json
@@ -123,5 +123,7 @@
 
     "greenColor": "rgb(0, 166, 90)",
 
-    "whiteColor": "rgb(255, 255, 255)"
+    "whiteColor": "rgb(255, 255, 255)",
+
+    "earliestBtnText": "Earliest"
 }


### PR DESCRIPTION

https://trello.com/c/GZXref9i/754-at041604-create-booking-page-departure-on-ui-by-default-earliest-button-has-text-earliest-in-white-color-fff-rgb255-255-255