### PR TITLE
RF_04.11.05 |Verify that when you click an invalid date in the Departure on, the date doesn't change

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.11_CalendarWeekFunc.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.11_CalendarWeekFunc.cy.js
@@ -111,9 +111,8 @@ describe('US_04.11 | Calendar week functionality', () => {
 				let selectedDay = $selDate.text();
 							
 				createBookingPage.getCalendarDays().each(($unDate) => {
-					let unavailableDay = $unDate;
-					if(unavailableDay.hasClass('unavailable')){
-						$unDate.on('click');
+					if($unDate.hasClass('unavailable')){
+						cy.wrap($unDate).click();
 						
 						createBookingPage.getLabelDepartureOnDate().then(($onDate) =>{
 							let onDate = $onDate.text().split(' ')[0];


### PR DESCRIPTION
[RF_04.11.05 |Verify that when you click an invalid date in the Departure on, the date doesn't change](https://trello.com/c/hu4mTY2L/785-rfat041105-create-booking-page-deparure-date-calendar-week-functionality-verify-that-when-you-click-an-invalid-date-in-the-depar)