### PR TITLE
AT_01.07.02 |  AT_01.07.02 | Start page > Verify the error message after click Sign In with an invalid email

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/US_01.07_LoginByEmailTab_negative.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/US_01.07_LoginByEmailTab_negative.cy.js
@@ -30,4 +30,21 @@ describe('US_01.07 | Login by email tab negative', () => {
             .should("be.visible")
             .and('have.text',this.startPage.alert.loginPopupMessageAlert);
         });
+
+    it('AT_01.07.02 | Verify the error message after click Sign In with an invalid email', function () {
+        loginPopup
+            .getEmailInput()
+            .clear()
+            .type(this.startPage.dataInvalid.invalidEmail);
+        loginPopup
+            .getPasswordInput()
+            .clear()
+            .type(this.startPage.dataInvalid.validPassword);
+        loginPopup
+            .clickByEmailSignInButton();
+        loginPopup
+            .getEmailErrorMessage()
+            .should("be.visible")
+            .and('include.text', this.startPage.dataInvalid.errorMessage);   
+    });
 });

--- a/cypress/fixtures/startPage.json
+++ b/cypress/fixtures/startPage.json
@@ -85,5 +85,10 @@
             "code": 66,
             "number": 616161616
         }
+    },
+    "dataInvalid": {
+        "errorMessage": "Something goes wrong. Please contact your country manager.",
+        "invalidEmail": "test@qatest.site",
+        "validPassword": "12345678"
     }
 }

--- a/cypress/pageObjects/StartPage.js
+++ b/cypress/pageObjects/StartPage.js
@@ -61,6 +61,7 @@ export class LoginPopup {
     getByPhoneSignInButton = () => cy.get('#step2 [value="SIGN IN"]');
     getPhoneNumberInputLabel = () => cy.get('div[class="col-sm-6 col-xs-8"] label');
     getLoginPopupModal =() => cy.get('#loginModal .modal-content');
+    getEmailErrorMessage = () => cy.get('.alert.alert-danger');
 
     // Methods
 


### PR DESCRIPTION
https://trello.com/c/OE0oCfPX/817-at010702-start-page-login-popup-login-by-email-tab-negative-verify-the-error-message-after-click-sign-in-with-an-invalid-email