### PR TITLE
AT_01.10.03 | registering is not possible with any letters 'Country code' input

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/US_01.10_LoginByPhoneNegative.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/US_01.10_LoginByPhoneNegative.cy.js
@@ -19,6 +19,8 @@ describe('US_01.10 | Login by phone negative', () => {
         cy.fixture('startPage').then(startPage => {
             this.startPage = startPage
         });
+        loginPopup.getCountryCodeInput().clear();
+        loginPopup.getPhoneNumberInput().clear();
     })
 
     it('AT_01.10.01 | Verify that registering is not possible with empty "Country code" input', function () {
@@ -28,9 +30,18 @@ describe('US_01.10 | Login by phone negative', () => {
     });
 
     it('AT_01.10.02 | Verify that registering is not possible with empty "Phone number" input', function () {
-        loginPopup.getPhoneNumberInput().clear()
         loginPopup.enterCountryCode(this.startPage.data.phoneNumber.code)
         loginPopup.clickRequestCodeButton();
         loginPopup.getMessageAlert().should('have.text', this.startPage.alert.loginPopupByPhoneMessageAlert);
     });
+
+    it('AT_01.10.03 | Verify that registering is not possible with any letters "Country code" input', function () {
+        loginPopup.enterCountryCode(this.startPage.dataInvalid.lettersInCountryCode);
+        loginPopup.enterPhoneNumber(this.startPage.data.phoneNumber.number);
+        loginPopup.clickRequestCodeButton();
+
+        loginPopup.getMessageAlert()
+            .should('be.visible')
+            .and('have.text', this.startPage.alert.loginPopupByPhoneMessageAlert);
+    })
 })

--- a/cypress/fixtures/startPage.json
+++ b/cypress/fixtures/startPage.json
@@ -89,6 +89,7 @@
     "dataInvalid": {
         "errorMessage": "Something goes wrong. Please contact your country manager.",
         "invalidEmail": "test@qatest.site",
-        "validPassword": "12345678"
+        "validPassword": "12345678", 
+        "lettersInCountryCode": "SK"
     }
 }


### PR DESCRIPTION
https://trello.com/c/1eWyUKiE/832-at011003-login-by-phone-negative-registering-is-not-possible-with-any-letters-country-code-input