### PR TITLE
AT_01.20.01 | Verify that the user is not able to restore the password with empty Email input

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/US_01.20_RestorePasswordPopupNegative.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/US_01.20_RestorePasswordPopupNegative.cy.js
@@ -1,0 +1,28 @@
+/// <reference types="cypress"/>
+
+import {StartPage} from "../../../pageObjects/StartPage.js";
+import {LoginPopup} from "../../../pageObjects/StartPage.js";
+import {RestorePopup} from "../../../pageObjects/StartPage.js";
+
+const startPage = new StartPage();
+const loginPopup = new LoginPopup();
+const restorePopup = new RestorePopup();
+
+describe ('US_01.20 | Start Page > Restore Password Negative', function() {
+    beforeEach(function () {
+        cy.fixture('startPage').then(startPage => {
+            this.startPage = startPage;
+        });
+        cy.visit('/');
+        startPage.clickLoginButton();
+        loginPopup.clickForgotYourPasswordLink();
+    });
+
+    it('AT_01.20.01 | Verify that the user is not able to restore the password with empty Email input', function() {
+        restorePopup.clickRestoreButton();
+        restorePopup
+            .getEnterEmailAlert()
+            .should('be.visible')
+            .and('have.text', this.startPage.alert.restorePasswordPopup.enterEmailAlert);
+    });
+});

--- a/cypress/fixtures/startPage.json
+++ b/cypress/fixtures/startPage.json
@@ -1,7 +1,8 @@
 {
     "alert": {
         "restorePasswordPopup": {
-            "alertMessage": "Please check your email with the password restore instructions"
+            "alertMessage": "Please check your email with the password restore instructions",
+            "enterEmailAlert": "Please enter your email"
         },
         "registerPopupErrorMessage": {
             "emptyNameField": "Please enter your name",

--- a/cypress/pageObjects/StartPage.js
+++ b/cypress/pageObjects/StartPage.js
@@ -124,6 +124,7 @@ export class RestorePopup {
     getRestorePopupCloseButton = () => cy.get('div#restoreModal .modal-header .close');
     getRestorePopupModal = () => cy.get('div#restoreModal');
     getRegisterLink = () => cy.get('.form-horizontal .modal-footer .pull-left a');
+    getEnterEmailAlert = () => cy.get('div.help-block.error')
 
     // Methods
 


### PR DESCRIPTION
https://trello.com/c/1fGcmoYI/846-at012001-start-page-restore-password-popup-verify-that-the-user-is-not-able-to-restore-the-password-with-empty-email-input