### PR TITLE
AT_01.20.03 | Start Page > Restore password Popup > Verify that the error message ‘Wrong email’ is displayed with two @ signs at the ‘Email’ input

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/US_01.20_RestorePasswordPopupNegative.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/US_01.20_RestorePasswordPopupNegative.cy.js
@@ -25,4 +25,13 @@ describe ('US_01.20 | Start Page > Restore Password Negative', function() {
             .should('be.visible')
             .and('have.text', this.startPage.alert.restorePasswordPopup.enterEmailAlert);
     });
+
+    it('AT_01.20.03 | Verify that the error message Wrong email is displayed with two @ signs at the Email input', function() {
+        restorePopup.enterEmail(this.startPage.data.invalidEmail);
+        restorePopup.clickRestoreButton();
+        restorePopup.getEnterEmailAlert()
+            .should('be.visible')
+            .and('have.text', this.startPage.alert.restorePasswordPopup.wrongEmail);
+
+    });
 });

--- a/cypress/fixtures/startPage.json
+++ b/cypress/fixtures/startPage.json
@@ -2,7 +2,8 @@
     "alert": {
         "restorePasswordPopup": {
             "alertMessage": "Please check your email with the password restore instructions",
-            "enterEmailAlert": "Please enter your email"
+            "enterEmailAlert": "Please enter your email",
+            "wrongEmail": "Wrong email"
         },
         "registerPopupErrorMessage": {
             "emptyNameField": "Please enter your name",
@@ -86,7 +87,8 @@
         "phoneNumber": {
             "code": 66,
             "number": 616161616
-        }
+        },
+        "invalidEmail": "test@@qatest.site"
     },
     "dataInvalid": {
         "errorMessage": "Something goes wrong. Please contact your country manager.",


### PR DESCRIPTION
https://trello.com/c/xKNHOYrH/853-at012003-start-page-restore-password-popup-verify-that-the-error-message-wrong-email-is-displayed-with-two-signs-at-the-email-in