### PR TITLE
AT_04.23.13 | Verify Fare type has “Adult” option displayed by default.

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.23_PassengersDetailsDefaultUI.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.23_PassengersDetailsDefaultUI.cy.js
@@ -73,4 +73,10 @@ describe('US_04.23 | Passengers details default UI', () => {
         
         createBookingPage.getDropdownPassengerDefault().should('have.text', this.createBookingPage.passengerDefault)
     });
+
+    it('AT_04.23.13 | Verify Fare type has “Adult” option displayed by default.', function ()  {
+        createBookingPage
+            .getFareTypeDropdown()
+            .should('have.text', this.createBookingPage.dropdowns.fareType.fareTypesNames[0]);
+    });
 });


### PR DESCRIPTION
https://trello.com/c/CH8b0Wyq/863-at042313-verify-fare-type-has-adult-option-displayed-by-default