### PR TITLE
AT_01.04.04 | Verify the text "No account yet?" is visible in the footer

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/US_01.04_LoginPopupFooterUIandFn.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/US_01.04_LoginPopupFooterUIandFn.cy.js
@@ -32,4 +32,8 @@ describe('US_01.04 | Login Popup Footer UI and Functionality', () => {
     it('AT_01.04.02 | Verify the link Register is visible in the footer', () => {
         loginPopup.getRegisterLink().should('be.visible')
     });
+
+    it('AT_01.04.04 | Verify the text "No account yet?" is visible in the footer', function () {
+        loginPopup.getNoAccountYet().should('be.visible')
+    });
 })

--- a/cypress/pageObjects/StartPage.js
+++ b/cypress/pageObjects/StartPage.js
@@ -62,6 +62,7 @@ export class LoginPopup {
     getPhoneNumberInputLabel = () => cy.get('div[class="col-sm-6 col-xs-8"] label');
     getLoginPopupModal =() => cy.get('#loginModal .modal-content');
     getEmailErrorMessage = () => cy.get('.alert.alert-danger');
+    getNoAccountYet = () => cy.get('#loginModal .pull-left');
    
     // Methods
 


### PR DESCRIPTION
https://trello.com/c/mRCVJ5ed/871-at010404-start-page-footer-verify-the-text-no-account-yet-is-visible-in-the-footer