### PR TITLE
AT_04.24.04 | Verify Notes/Remark input field has a “Booking notes” text placeholder and is visible

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.24_Multiple_passengers_UI.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.24_Multiple_passengers_UI.cy.js
@@ -44,10 +44,10 @@ describe('US_04.24 | Multiple passengers UI', () => {
             .and('equal', this.createBookingPage.dropdowns.fareType.fareTypesNames[0]);
     });
 
-    it('AT_04.24.04 | Verify Notes/Remark input field has a “Booking notes” text placeholder and is visible', function ()  {
+    it.only('AT_04.24.04 | Verify Notes/Remark input field has a “Booking notes” text placeholder and is visible', function ()  {
         createBookingPage
             .getNotesInputField()
             .should('be.visible')
-            .should('have.attr', 'placeholder', this.createBookingPage.placeholder.notes);
+            .and('have.attr', 'placeholder', this.createBookingPage.placeholder.notes);
     });
 });    

--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.24_Multiple_passengers_UI.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.24_Multiple_passengers_UI.cy.js
@@ -44,7 +44,7 @@ describe('US_04.24 | Multiple passengers UI', () => {
             .and('equal', this.createBookingPage.dropdowns.fareType.fareTypesNames[0]);
     });
 
-    it.only('AT_04.24.04 | Verify Notes/Remark input field has a “Booking notes” text placeholder and is visible', function ()  {
+    it('AT_04.24.04 | Verify Notes/Remark input field has a “Booking notes” text placeholder and is visible', function ()  {
         createBookingPage
             .getNotesInputField()
             .should('be.visible')

--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.24_Multiple_passengers_UI.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.24_Multiple_passengers_UI.cy.js
@@ -43,4 +43,10 @@ describe('US_04.24 | Multiple passengers UI', () => {
             .should('have.attr', 'title')
             .and('equal', this.createBookingPage.dropdowns.fareType.fareTypesNames[0]);
     });
+
+    it('AT_04.24.04 | Verify Notes/Remark input field has a “Booking notes” text placeholder and is visible', function ()  {
+        createBookingPage
+            .getNotesInputField()
+            .should('have.attr', 'placeholder', this.createBookingPage.placeholder.notes);
+    });
 });    

--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.24_Multiple_passengers_UI.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.24_Multiple_passengers_UI.cy.js
@@ -47,6 +47,7 @@ describe('US_04.24 | Multiple passengers UI', () => {
     it('AT_04.24.04 | Verify Notes/Remark input field has a “Booking notes” text placeholder and is visible', function ()  {
         createBookingPage
             .getNotesInputField()
+            .should('be.visible')
             .should('have.attr', 'placeholder', this.createBookingPage.placeholder.notes);
     });
 });    


### PR DESCRIPTION
https://trello.com/c/Q4VPdC4u/872-at042404-verify-notes-remark-input-field-has-a-booking-notes-text-placeholder