### PR TITLE
RF | AT_04.22.06 | Verify when after clicking on the "Earliest" tab, user should the earliest available trip on a left

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.22_TripCardFunc.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.22_TripCardFunc.cy.js
@@ -62,6 +62,9 @@ describe('US_04.22 | Trip card functionality', () => {
     })
 
     it('AT_04.22.06| Verify when after clicking on the "Earliest" tab, user should the earliest available trip on a left', function() {
+        createBookingPage.clickDepartureErliestButton() 
+        createBookingPage.clickDepartureErliestButton() 
+        
         createBookingPage.getBtnErliest().should('have.class', 'selected')      
         const ordersSequence = []
         createBookingPage.getDepartureTripCardsList().each(($el, i) => {

--- a/cypress/pageObjects/CreateBookingPage.js
+++ b/cypress/pageObjects/CreateBookingPage.js
@@ -178,6 +178,10 @@ class CreateBookingPage {
         this.getDepartureLatestButton().click({ force: true })
     };
 
+    clickDepartureErliestButton() {
+        this.getBtnErliest().click({ force: true })
+    };
+
     getRandomIndexOfMonth() {
 
         return this.getMonthDropdownList().then($el => {


### PR DESCRIPTION
https://trello.com/c/O9DqME7h/883-rf-at042206-verify-when-after-clicking-on-the-earliest-tab-user-should-the-earliest-available-trip-on-a-left