### PR TITLE
AT_04.07.03 | Verify that the background of the selected item in the Dropdown Menu has gray color (#DDDDDD).

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.07_ArrivalDropdown.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.07_ArrivalDropdown.cy.js
@@ -29,4 +29,15 @@ describe('US_04.07_Arrival Dropdown UI and functionality ', () => {
         createBookingPage.clickArrivalStationDropdown()
         createBookingPage.getArrivalStationList().should('be.visible')
     });
+
+    it('AT_04.07.03 | Verify that the background of the selected item in the Dropdown Menu has gray color (#DDDDDD).', function() {
+        createBookingPage.selectNeedArrivalStation(this.createBookingPage.dropdowns.arrivalStation.stationsNames[2])
+        createBookingPage.hoverNeedArrivalStation(this.createBookingPage.dropdowns.arrivalStation.stationsNames[1])
+        createBookingPage.getArrivalStationList().each($el => {
+            if($el.text() == this.createBookingPage.dropdowns.arrivalStation.stationsNames[2]){ 
+                              
+                expect($el).to.have.css('background-color', this.colors.greyDropdownBack)
+            }
+        })
+    })
 })

--- a/cypress/pageObjects/CreateBookingPage.js
+++ b/cypress/pageObjects/CreateBookingPage.js
@@ -392,5 +392,25 @@ class CreateBookingPage {
         this.getMainPassengerFareTypeDropdownSelect()
             .select(FareType, { force: true })        
     }
+
+    selectNeedArrivalStation(nameStation) {
+        this.getCreateBookingHeader().click()
+        this.clickArrivalStationDropdown()
+        this.getArrivalStationList().each(($el) => {
+            if ($el.text() == nameStation) {
+                cy.wrap($el).click({ force: true })
+            }
+        })
+    }
+
+    hoverNeedArrivalStation(nameStation) {
+        this.getCreateBookingHeader().click({ force: true })
+        this.clickArrivalStationDropdown()
+        this.getArrivalStationList().each(($el) => {
+            if ($el.text() == nameStation) {
+                cy.wrap($el).trigger('mouseover')
+            }
+        })
+    }
 }
 export default CreateBookingPage;


### PR DESCRIPTION
TC - https://trello.com/c/qiwZUZ9f/903-tc040703-arrival-dropdown-ui-and-functionality-verify-that-the-background-of-the-selected-item-in-the-dropdown-menu-has-gray-col

AT - https://trello.com/c/g7lnWc2T/904-at040703-arrival-dropdown-ui-and-functionality-verify-that-the-background-of-the-selected-item-in-the-dropdown-menu-has-gray-col