### PR TITLE
AT_01.10.05 | Verify that registering is not possible with any symbols "Country code" input'

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/US_01.10_LoginByPhoneNegative.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/US_01.10_LoginByPhoneNegative.cy.js
@@ -54,4 +54,14 @@ describe('US_01.10 | Login by phone negative', () => {
         .should('be.visible')
         .and('have.text', this.startPage.alert.loginPopupByPhoneWrongNumberAlert);
     })
+
+    it('AT_01.10.05 | Verify that registering is not possible with any symbols "Country code" input', function() {
+        loginPopup.enterCountryCode(this.startPage.dataInvalid.symbolsInCountryCode);
+        loginPopup.enterPhoneNumber(this.startPage.data.phoneNumber.number);
+        loginPopup.clickRequestCodeButton();
+
+        loginPopup.getMessageAlert()
+            .should('be.visible')
+            .and('have.text', this.startPage.alert.loginPopupByPhoneMessageAlert);
+    });
 })

--- a/cypress/fixtures/startPage.json
+++ b/cypress/fixtures/startPage.json
@@ -95,7 +95,7 @@
         "invalidEmail": "test@qatest.site",
         "validPassword": "12345678", 
         "lettersInCountryCode": "SK",
-        "letterInPhoneNumber": "61616161A"
-        
+        "letterInPhoneNumber": "61616161A",
+        "symbolsInCountryCode": "%@"
     }
 }


### PR DESCRIPTION
https://trello.com/c/gsevCbep/912-at011005-start-page-login-by-phone-negative-verify-that-registering-is-not-possible-with-any-symbols-country-code-input