### PR TITLE
AT_04.07.04 | Verify that the background of the newly selected item changes color to green(#00A65A) when the item is selected.

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.07_ArrivalDropdown.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.07_ArrivalDropdown.cy.js
@@ -40,4 +40,14 @@ describe('US_04.07_Arrival Dropdown UI and functionality ', () => {
             }
         })
     })
+
+    it('AT_04.07.04 | Verify that the background of the newly selected item changes color to green(#00A65A) when the item is selected.', function() {
+        createBookingPage.hoverNeedArrivalStation(this.createBookingPage.dropdowns.arrivalStation.stationsNames[1])
+        createBookingPage.getArrivalStationList().each($el => {
+            if($el.text() == this.createBookingPage.dropdowns.arrivalStation.stationsNames[1]) {
+
+                expect($el).to.have.css('background-color', this.colors.greenBookingPage)
+            }
+        })
+    })
 })


### PR DESCRIPTION
TC - https://trello.com/c/RZiaebQ2/940-tc040704-arrival-dropdown-ui-and-functionality-verify-that-the-background-of-the-newly-selected-item-changes-color-to-green00a65

AT - https://trello.com/c/1vo64A1z/941-at040704-arrival-dropdown-ui-and-functionality-verify-that-the-background-of-the-newly-selected-item-changes-color-to-green00a65