### PR TITLE
AT_04.19.01 | Verify Trips card with "Number available tickets" label is visible as unselected

### DIFF
--- a/cypress/e2e/testUiAndFunction/createBookingPage/US_04.19_UnselectedTripCardAvailable.cy.js
+++ b/cypress/e2e/testUiAndFunction/createBookingPage/US_04.19_UnselectedTripCardAvailable.cy.js
@@ -1,0 +1,25 @@
+/// <reference types ="cypress" />
+
+import CreateBookingPage from "../../../pageObjects/CreateBookingPage";
+import waitForToolsPing from "../../../support/utilities/waitForToolsPing";
+
+const createBookingPage = new CreateBookingPage();
+
+const AGENT = Cypress.env('agent');
+
+describe('US_04.19 | Unselected trip card available UI', function() {
+
+    before(() => {
+        cy.visit('/');
+        cy.login(AGENT.email, AGENT.password);
+        createBookingPage.clickCalendarNextButton(); 
+        waitForToolsPing();          
+    });
+
+    it('AT_04.19.01 | Verify Trips card with "Number available tickets" label is visible as unselected', function() {
+        createBookingPage.getDepartureTripCardsList().each($el => {
+            cy.wrap($el).should('be.visible')
+                        .and('not.have.class', 'selected')  
+        })
+    });
+});


### PR DESCRIPTION
https://trello.com/c/L5PjPyHL/947-at041901-create-booking-page-unselected-trip-card-available-ui-verify-trips-card-with-number-available-tickets-label-is-visible