### PR TITLE
AT_01.20.02 | Verify that the user is not able to restore the password with a missing domain at the Email input

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/US_01.20_RestorePasswordPopupNegative.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/US_01.20_RestorePasswordPopupNegative.cy.js
@@ -34,4 +34,12 @@ describe ('US_01.20 | Start Page > Restore Password Negative', function() {
             .and('have.text', this.startPage.alert.restorePasswordPopup.wrongEmail);
 
     });
+
+    it('AT_01.20.02 | Verify that the user is not able to restore the password with a missing domain at the Email input', function() {
+        restorePopup.enterEmail(this.startPage.dataInvalid.missingDomainEmail);
+        restorePopup.clickRestoreButton();
+        restorePopup.getEnterEmailAlert()
+            .should('be.visible')
+            .and('have.text', this.startPage.alert.restorePasswordPopup.wrongEmail);
+    });
 });

--- a/cypress/fixtures/startPage.json
+++ b/cypress/fixtures/startPage.json
@@ -96,6 +96,7 @@
         "validPassword": "12345678", 
         "lettersInCountryCode": "SK",
         "letterInPhoneNumber": "61616161A",
-        "symbolsInCountryCode": "%@"
+        "symbolsInCountryCode": "%@",
+        "missingDomainEmail": "test@"
     }
 }


### PR DESCRIPTION
https://trello.com/c/US378qhU/972-tc012002-start-page-restore-password-popup-verify-that-the-user-is-not-able-to-restore-the-password-with-a-missing-domain-at-the