### PR TITLE
AT_01.14.08 | Verify that the example(placeholder) "Country code and phone number" is visible in the email field, has the #666 color, and font size: 14px'

### DIFF
--- a/cypress/e2e/testUiAndFunction/startPage/US_01.14_Register_UI.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/US_01.14_Register_UI.cy.js
@@ -83,4 +83,14 @@ describe('US_01.14 | Register UI', () => {
             .and('have.css', 'color', this.colors.greyLabel)
             .and('have.css', 'font-size', this.startPage.label.labelsModalBody.front_size)
     }) 
+
+    it('AT_01.14.08 | Verify that the example(placeholder) "Country code and phone number" is visible in the email field, has the #666 color, and font size: 14px' , function () {
+        registerPopup
+            .getPhoneInput()
+            .should('be.visible')
+            .and('have.attr', 'placeholder', this.startPage.inputField.registerPopup.phoneNumberInputField)
+            .and('have.css', 'color', this.colors.greyHeader)
+            .and('have.css', 'font-size', this.startPage.label.labelsModalBody.front_size)
+    })
+    
 })

--- a/cypress/e2e/testUiAndFunction/startPage/US_01.14_Register_UI.cy.js
+++ b/cypress/e2e/testUiAndFunction/startPage/US_01.14_Register_UI.cy.js
@@ -66,7 +66,7 @@ describe('US_01.14 | Register UI', () => {
             .and('have.css', 'font-size', this.startPage.label.labelsModalBody.front_size)
     }) 
      
-    it('AT_01.14.06 | Verify that the example(placeholder) "agent@qatest.site" is visible in the email field, has the #666 color, and font size: 14px' , function () {
+    it('AT_01.14.06 | Verify that the example(placeholder) "You will get your password by email" is visible in the email field, has the #666 color, and font size: 14px' , function () {
         registerPopup
             .getEmailInput()
             .should('be.visible')
@@ -75,4 +75,12 @@ describe('US_01.14 | Register UI', () => {
             .and('have.css', 'font-size', this.startPage.label.labelsModalBody.front_size)
     })
     
+    it('AT_01.14.07 | Verify that the label "Phone number" is visible in the modal body, has the #999 color and font size: 14px' , function () {
+        registerPopup
+            .getPhoneLabel()
+            .should('be.visible')
+            .and('include.text', this.startPage.label.labelPhoneNumber.text)
+            .and('have.css', 'color', this.colors.greyLabel)
+            .and('have.css', 'font-size', this.startPage.label.labelsModalBody.front_size)
+    }) 
 })

--- a/cypress/pageObjects/StartPage.js
+++ b/cypress/pageObjects/StartPage.js
@@ -163,6 +163,7 @@ export class RegisterPopup {
     getRegisterCongratulationsHeader = () => cy.get('#registerModal .modal-dialog .modal-header h2.text-center');
     getCompanyNameLabel = () => cy.get('#registerModal .modal-body div:nth-child(2) label');
     getEmailLabel = () => cy.get('#registerModal .modal-body div:nth-child(3) label');
+    getPhoneLabel = () => cy.get('#registerModal .modal-body div:nth-child(4) label');
     
     // Methods
 


### PR DESCRIPTION
https://trello.com/c/tUB0bblJ/1041-at011408-country-code-and-phone-number